### PR TITLE
fix: prevent localhost URLs from being published, correct CI URLs

### DIFF
--- a/.scripts/replaceKeys.js
+++ b/.scripts/replaceKeys.js
@@ -14,6 +14,12 @@ function replaceKeys({ filePath, envVars }) {
       return;
     }
 
+    if (/localhost|127\.0\.0\.1/.test(process.env[key])) {
+      console.error(`🚨 Refusing to bake localhost URL into bundle: ${key}=${process.env[key]}`);
+      console.error(`   This would publish a broken CLI. Fix your env vars and retry.`);
+      process.exit(1);
+    }
+
     content = content.replace(`process.env.${key}`, `"${process.env[key]}"`);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternatefutures/cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Unified command line interface to Alternate Clouds - decentralized cloud infrastructure with censorship resistance",
   "license": "AGPL-3.0-only",
   "author": "Alternate Futures",

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -27,8 +27,12 @@ export const parseEnvVarsAsKeyVal = <T extends Record<string, string>>({
       }
 
       if (/localhost|127\.0\.0\.1/.test(value)) {
-        console.error(`🚨 Refusing to bake localhost URL into bundle: ${envName}=${value}`);
-        console.error(`   This would publish a broken CLI. Fix your env vars and retry.`);
+        console.error(
+          `🚨 Refusing to bake localhost URL into bundle: ${envName}=${value}`,
+        );
+        console.error(
+          '   This would publish a broken CLI. Fix your env vars and retry.',
+        );
         process.exit(1);
       }
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -20,13 +20,19 @@ export const parseEnvVarsAsKeyVal = <T extends Record<string, string>>({
 
   return keys.reduce(
     (define, envName) => {
-      if (!defined[envName as keyof T]) {
+      const value = defined[envName as keyof T];
+
+      if (!value) {
         throw new EnvNotSetError(envName);
       }
 
-      define[`${keyPrefix}${envName}`] = JSON.stringify(
-        defined[envName as keyof T],
-      );
+      if (/localhost|127\.0\.0\.1/.test(value)) {
+        console.error(`🚨 Refusing to bake localhost URL into bundle: ${envName}=${value}`);
+        console.error(`   This would publish a broken CLI. Fix your env vars and retry.`);
+        process.exit(1);
+      }
+
+      define[`${keyPrefix}${envName}`] = JSON.stringify(value);
 
       return define;
     },


### PR DESCRIPTION
- Add localhost guard to .scripts/replaceKeys.js: aborts build if any env var value contains localhost or 127.0.0.1 (prevents accidental publish of dev URLs like the 0.2.5 incident)
- Add same guard to src/utils/env.ts parseEnvVarsAsKeyVal (esbuild path)
- Bump version to 0.2.6
- Note: npm-publish.yml URLs and europlots fallback already correct on main

## Why?

Package published with localhost urls

## How?

Trying to publish with localhost urls throws a helpful error now



