### PR TITLE
fix: trigger npm-publish on tag push instead of release event

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,9 @@
 name: 📦 Publish to npm
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary

- Switches `npm-publish.yml` trigger from `release: published` to `push: tags: ['v*']`
- `workflow_dispatch` is kept unchanged as a manual escape hatch

## Why

The `release: published` event didn't fire reliably for releases created via `gh release create` automation. This was observed during the v0.2.6 publish (Apr 10, 2026) — the release was created but no workflow run was triggered, and a manual `gh workflow run npm-publish.yml --field tag=v0.2.6` was needed to actually publish.

Tag pushes are a more robust trigger because:
1. They fire regardless of who creates the tag (user, bot, automation)
2. They are the actual source of truth for "what version should be published"
3. `gh release create vX.Y.Z` pushes the tag as part of the release creation, so nothing changes in the developer flow

## Changes

Only `.github/workflows/npm-publish.yml` — the `on:` block:

```diff
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     ...
```

No changes to job steps, env vars, permissions, or the `ref: ${{ inputs.tag || github.ref }}` checkout (tag pushes set `github.ref` to `refs/tags/vX.Y.Z`, which is valid).

## Test plan

- [ ] After merge, the next release created via `gh release create vX.Y.Z --generate-notes` will push the tag, which will automatically trigger npm-publish
- [ ] Alternatively, a bare `git tag vX.Y.Z && git push origin vX.Y.Z` also triggers it
- [ ] `workflow_dispatch` still works for manual retries

Closes #84