### PR TITLE
chore: sync develop → main (v0.2.7)

### DIFF
--- a/.changeset/claude-skill-for-ai-assistants.md
+++ b/.changeset/claude-skill-for-ai-assistants.md
@@ -1,0 +1,5 @@
+---
+"@alternatefutures/cli": patch
+---
+
+Add `.claude/skills/af-cli/SKILL.md` so AI assistants (Claude Code, Cursor, etc.) load an accurate, hand-maintained reference for every `af` command, flag, and workflow when working in repos that depend on the CLI. No code changes.

--- a/.changeset/claude-skill-for-ai-assistants.md
+++ b/.changeset/claude-skill-for-ai-assistants.md
@@ -1,5 +1,0 @@
----
-"@alternatefutures/cli": patch
----
-
-Add `.claude/skills/af-cli/SKILL.md` so AI assistants (Claude Code, Cursor, etc.) load an accurate, hand-maintained reference for every `af` command, flag, and workflow when working in repos that depend on the CLI. No code changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   lint-and-typecheck:
     name: Lint & Type Check
     runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,8 +28,8 @@ jobs:
           cache: pnpm
 
       - name: Configure npm registry
-        if: ${{ secrets.NPM_TOKEN != '' }}
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+        if: ${{ env.NPM_TOKEN != '' }}
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.7
+
+### Patch Changes
+
+- 12fc13c: Add `.claude/skills/af-cli/SKILL.md` so AI assistants (Claude Code, Cursor, etc.) load an accurate, hand-maintained reference for every `af` command, flag, and workflow when working in repos that depend on the CLI. No code changes.
+
 ## 0.2.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternatefutures/cli",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Unified command line interface to Alternate Clouds - decentralized cloud infrastructure with censorship resistance",
   "license": "AGPL-3.0-only",
   "author": "Alternate Futures",


### PR DESCRIPTION
## Summary
Forward-merge \`develop\` into \`main\` after the v0.2.7 release. Brings main up to date with:

- **ci.yml fix** (#92) — main currently still has the broken \`secrets in step-level if:\` that was failing every push
- **Changeset entry consumption** — \`.changeset/claude-skill-for-ai-assistants.md\` removed by the bot after the version bump
- **\`package.json\`** \`0.2.6 → 0.2.7\` so main matches the published npm version

After this lands, \`develop\` and \`main\` will be aligned at the v0.2.7 tag (\`fdc28252\`).

## Why
The release flow runs from develop, but main has been receiving direct PR merges (e.g. #90). Without periodic sync, main drifts behind develop and its CI keeps failing.

## Test plan
- [ ] Confirm CI on main passes after merge (validates the #92 fix)
- [ ] Confirm \`git diff develop main\` returns empty post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)